### PR TITLE
Adds version requirements for networkx in setup.py

### DIFF
--- a/target/setup.py
+++ b/target/setup.py
@@ -8,5 +8,5 @@ setup(name='target',
     author='James Flamino',
     author_email='flamij@rpi.edu',
     packages=['tools'],
-    install_requires = ['numpy', 'sklearn', 'networkx', 'pandas', 'hdbscan', 'matplotlib', 'dask[complete]']
+    install_requires = ['numpy', 'sklearn', 'networkx>=1.9.1,<2.4', 'pandas', 'hdbscan', 'matplotlib', 'dask[complete]']
 )


### PR DESCRIPTION
This is a small fix adding the version requirements for the networkx package. Version 2.4 came out last fall, but the function call 'connected_component_subgraphs' was removed in this version. Versions 2.3 and bellow should be okay.